### PR TITLE
Rebase polymer develop to match v0.0.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ setup:
 run:
 	@go run ./cmd/erpc/main.go
 
+.PHONY: run-pprof
+run-pprof:
+	@go run ./cmd/erpc/main.go ./cmd/erpc/pprof.go
+
 .PHONY: run-fake-rpcs
 run-fake-rpcs:
 	@go run ./test/cmd/main.go

--- a/cmd/erpc/pprof.go
+++ b/cmd/erpc/pprof.go
@@ -4,9 +4,9 @@
 package main
 
 import (
-	"runtime"
 	"net/http"
 	_ "net/http/pprof"
+	"runtime"
 
 	"github.com/rs/zerolog/log"
 )

--- a/cmd/erpc/pprof.go
+++ b/cmd/erpc/pprof.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"runtime"
 	"net/http"
 	_ "net/http/pprof"
 
@@ -12,6 +13,8 @@ import (
 
 func init() {
 	go func() {
+		runtime.SetMutexProfileFraction(1)
+		runtime.SetBlockProfileRate(1)
 		log.Info().Msgf("pprof server started at http://localhost:6060")
 		http.ListenAndServe("0.0.0.0:6060", nil)
 	}()

--- a/common/errors.go
+++ b/common/errors.go
@@ -624,11 +624,11 @@ var NewErrUpstreamsExhausted = func(
 ) error {
 	// TODO create a new error type that holds a map to avoid creating a new array
 	ers := []error{}
-	req.Mu.RLock()
+	req.RLock()
 	for _, err := range ersObj {
 		ers = append(ers, err)
 	}
-	req.Mu.RUnlock()
+	req.RUnlock()
 	e := &ErrUpstreamsExhausted{
 		BaseError{
 			Code:    ErrCodeUpstreamsExhausted,

--- a/common/evm_block_ref.go
+++ b/common/evm_block_ref.go
@@ -34,6 +34,9 @@ func ExtractEvmBlockReferenceFromRequest(r *JsonRpcRequest) (string, int64, erro
 		return "", 0, errors.New("cannot extract block reference when json-rpc request is nil")
 	}
 
+	r.RLock()
+	defer r.RUnlock()
+
 	switch r.Method {
 	case "eth_getBlockByNumber",
 		"eth_getUncleByBlockNumberAndIndex",
@@ -166,6 +169,8 @@ func ExtractEvmBlockReferenceFromResponse(rpcReq *JsonRpcRequest, rpcResp *JsonR
 			if err != nil {
 				return "", 0, err
 			}
+			rpcResp.RLock()
+			defer rpcResp.RUnlock()
 			if tx, ok := result.(map[string]interface{}); ok {
 				var blockRef string
 				var blockNumber int64
@@ -189,7 +194,8 @@ func ExtractEvmBlockReferenceFromResponse(rpcReq *JsonRpcRequest, rpcResp *JsonR
 			if err != nil {
 				return "", 0, err
 			}
-
+			rpcResp.RLock()
+			defer rpcResp.RUnlock()
 			if blk, ok := result.(map[string]interface{}); ok {
 				var blockRef string
 				var blockNumber int64

--- a/common/evm_json_rpc.go
+++ b/common/evm_json_rpc.go
@@ -6,8 +6,8 @@ import (
 )
 
 func NormalizeEvmHttpJsonRpc(nrq *NormalizedRequest, r *JsonRpcRequest) error {
-	nrq.Mu.Lock()
-	defer nrq.Mu.Unlock()
+	r.Lock()
+	defer r.Unlock()
 
 	switch r.Method {
 	case "eth_getBlockByNumber",

--- a/common/json_rpc.go
+++ b/common/json_rpc.go
@@ -8,19 +8,15 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/bytedance/sonic"
 	"github.com/rs/zerolog"
 )
 
-type JsonRpcRequest struct {
-	JSONRPC string        `json:"jsonrpc,omitempty"`
-	ID      interface{}   `json:"id,omitempty"`
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
-}
-
 type JsonRpcResponse struct {
+	sync.RWMutex
+
 	JSONRPC string                       `json:"jsonrpc,omitempty"`
 	ID      interface{}                  `json:"id,omitempty"`
 	Result  json.RawMessage              `json:"result,omitempty"`
@@ -43,6 +39,17 @@ func NewJsonRpcResponse(id interface{}, result interface{}, rpcError *ErrJsonRpc
 }
 
 func (r *JsonRpcResponse) ParsedResult() (interface{}, error) {
+	r.RLock()
+	if r.parsedResult != nil {
+		defer r.RUnlock()
+		return r.parsedResult, nil
+	}
+	r.RUnlock()
+
+	r.Lock()
+	defer r.Unlock()
+
+	// Double-check in case another goroutine initialized it
 	if r.parsedResult != nil {
 		return r.parsedResult, nil
 	}
@@ -66,76 +73,14 @@ func (r *JsonRpcResponse) ParsedResult() (interface{}, error) {
 	return r.parsedResult, nil
 }
 
-func (r *JsonRpcRequest) MarshalZerologObject(e *zerolog.Event) {
-	if r == nil {
-		return
-	}
-	e.Str("method", r.Method).
-		Interface("params", r.Params).
-		Interface("id", r.ID)
-}
-
-func (r *JsonRpcRequest) CacheHash() (string, error) {
-	hasher := sha256.New()
-
-	for _, p := range r.Params {
-		err := hashValue(hasher, p)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	b := sha256.Sum256(hasher.Sum(nil))
-	return fmt.Sprintf("%s:%x", r.Method, b), nil
-}
-
-func hashValue(h io.Writer, v interface{}) error {
-	switch t := v.(type) {
-	case bool:
-		_, err := h.Write([]byte(fmt.Sprintf("%t", t)))
-		return err
-	case int:
-		_, err := h.Write([]byte(fmt.Sprintf("%d", t)))
-		return err
-	case float64:
-		_, err := h.Write([]byte(fmt.Sprintf("%f", t)))
-		return err
-	case string:
-		_, err := h.Write([]byte(strings.ToLower(t)))
-		return err
-	case []interface{}:
-		for _, i := range t {
-			err := hashValue(h, i)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	case map[string]interface{}:
-		keys := make([]string, 0, len(t))
-		for k := range t {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			if _, err := h.Write([]byte(k)); err != nil {
-				return err
-			}
-			err := hashValue(h, t[k])
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported type for value during hash: %+v", v)
-	}
-}
-
 func (r *JsonRpcResponse) MarshalZerologObject(e *zerolog.Event) {
 	if r == nil {
 		return
 	}
+
+	r.Lock()
+	defer r.Unlock()
+
 	e.Interface("id", r.ID).
 		Interface("result", r.Result).
 		Interface("error", r.Error)
@@ -143,6 +88,13 @@ func (r *JsonRpcResponse) MarshalZerologObject(e *zerolog.Event) {
 
 // Custom unmarshal method for JsonRpcResponse
 func (r *JsonRpcResponse) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return nil
+	}
+
+	r.Lock()
+	defer r.Unlock()
+
 	type Alias JsonRpcResponse
 	aux := &struct {
 		Error json.RawMessage `json:"error,omitempty"`
@@ -248,6 +200,88 @@ func (r *JsonRpcResponse) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+type JsonRpcRequest struct {
+	sync.RWMutex
+
+	JSONRPC string        `json:"jsonrpc,omitempty"`
+	ID      interface{}   `json:"id,omitempty"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+func (r *JsonRpcRequest) MarshalZerologObject(e *zerolog.Event) {
+	if r == nil {
+		return
+	}
+	e.Str("method", r.Method).
+		Interface("params", r.Params).
+		Interface("id", r.ID)
+}
+
+func (r *JsonRpcRequest) CacheHash() (string, error) {
+	if r == nil {
+		return "", nil
+	}
+
+	r.RLock()
+	defer r.RUnlock()
+
+	hasher := sha256.New()
+
+	for _, p := range r.Params {
+		err := hashValue(hasher, p)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	b := sha256.Sum256(hasher.Sum(nil))
+	return fmt.Sprintf("%s:%x", r.Method, b), nil
+}
+
+func hashValue(h io.Writer, v interface{}) error {
+	switch t := v.(type) {
+	case bool:
+		_, err := h.Write([]byte(fmt.Sprintf("%t", t)))
+		return err
+	case int:
+		_, err := h.Write([]byte(fmt.Sprintf("%d", t)))
+		return err
+	case float64:
+		_, err := h.Write([]byte(fmt.Sprintf("%f", t)))
+		return err
+	case string:
+		_, err := h.Write([]byte(strings.ToLower(t)))
+		return err
+	case []interface{}:
+		for _, i := range t {
+			err := hashValue(h, i)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]interface{}:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if _, err := h.Write([]byte(k)); err != nil {
+				return err
+			}
+			err := hashValue(h, t[k])
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported type for value during hash: %+v", v)
+	}
 }
 
 // TranslateToJsonRpcException is mainly responsible to translate internal eRPC errors (not those coming from upstreams) to

--- a/data/redis.go
+++ b/data/redis.go
@@ -134,11 +134,10 @@ func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value 
 	}
 
 	r.logger.Debug().Msgf("writing to Redis with partition key: %s and range key: %s", partitionKey, rangeKey)
-
-	ttl := time.Duration(0)
-	if strings.HasSuffix(partitionKey, ":nil") {
-		method := strings.ToLower(strings.Split(rangeKey, ":")[0])
-		ttl = r.ttls[method]
+	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
+	ttl, found := r.ttls[method]
+	if !found {
+		ttl = time.Duration(0)
 	}
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	rs := r.client.Set(ctx, key, value, ttl)

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -137,6 +137,15 @@ func (c *EvmJsonRpcCache) Set(ctx context.Context, req *common.NormalizedRequest
 
 	hasTTL := c.conn.HasTTL(rpcReq.Method)
 
+	if blockRef == "" && blockNumber == 0 && !hasTTL {
+		// Do not cache if we can't resolve a block reference (e.g. latest block requests)
+		lg.Debug().
+			Str("blockRef", blockRef).
+			Int64("blockNumber", blockNumber).
+			Msg("will not cache the response because it has no block reference or block number")
+		return nil
+	}
+
 	if !hasTTL {
 		if blockRef == "" && blockNumber == 0 {
 			// Do not cache if we can't resolve a block reference (e.g. latest block requests)

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -65,7 +65,6 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 
 	hasTTL := c.conn.HasTTL(rpcReq.Method)
 
-	req.Mu.RLock()
 	blockRef, blockNumber, err := common.ExtractEvmBlockReferenceFromRequest(rpcReq)
 	if err != nil {
 		return nil, err

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -67,7 +67,6 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 
 	req.Mu.RLock()
 	blockRef, blockNumber, err := common.ExtractEvmBlockReferenceFromRequest(rpcReq)
-	req.Mu.RUnlock()
 	if err != nil {
 		return nil, err
 	}
@@ -131,9 +130,7 @@ func (c *EvmJsonRpcCache) Set(ctx context.Context, req *common.NormalizedRequest
 		return err
 	}
 
-	req.Mu.RLock()
 	blockRef, blockNumber, err := common.ExtractEvmBlockReference(rpcReq, rpcResp)
-	req.Mu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -115,7 +115,7 @@ func (s *HttpServer) createRequestHandler(mainCtx context.Context, reqMaxTimeout
 
 		project, err := s.erpc.GetProject(projectId)
 		if err != nil {
-			handleErrorResponse(s.logger, nil, err, fastCtx, encoder, buf)
+			handleErrorResponse(&lg, nil, err, fastCtx, encoder, buf)
 			return
 		}
 

--- a/erpc/http_server.go
+++ b/erpc/http_server.go
@@ -397,7 +397,7 @@ func setResponseStatusCode(respOrErr interface{}, fastCtx *fasthttp.RequestCtx) 
 func processErrorBody(logger *zerolog.Logger, nq *common.NormalizedRequest, err error) interface{} {
 	if !common.IsNull(err) {
 		if nq != nil {
-			nq.Mu.RLock()
+			nq.RLock()
 		}
 		if common.HasErrorCode(err, common.ErrCodeEndpointClientSideException) {
 			logger.Debug().Err(err).Object("request", nq).Msgf("forward request errored with client-side exception")
@@ -409,7 +409,7 @@ func processErrorBody(logger *zerolog.Logger, nq *common.NormalizedRequest, err 
 			}
 		}
 		if nq != nil {
-			nq.Mu.RUnlock()
+			nq.RUnlock()
 		}
 	}
 

--- a/erpc/http_server_test.go
+++ b/erpc/http_server_test.go
@@ -2,7 +2,6 @@ package erpc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -13,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/erpc/erpc/common"
 	"github.com/h2non/gock"
 	"github.com/rs/zerolog"
@@ -293,7 +293,7 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 			assert.Equal(t, http.StatusOK, result.statusCode, "Status code should be 200 for request %d", i)
 
 			var response map[string]interface{}
-			err := json.Unmarshal([]byte(result.body), &response)
+			err := sonic.Unmarshal([]byte(result.body), &response)
 			assert.NoError(t, err, "Should be able to decode response for request %d", i)
 			assert.Equal(t, "0x444444", response["result"], "Unexpected result for request %d", i)
 		}
@@ -309,12 +309,12 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, statusCode)
 
 		var errorResponse map[string]interface{}
-		err := json.Unmarshal([]byte(body), &errorResponse)
+		err := sonic.Unmarshal([]byte(body), &errorResponse)
 		require.NoError(t, err)
 
 		assert.Contains(t, errorResponse, "error")
 		errorObj := errorResponse["error"].(map[string]interface{})
-		errStr, _ := json.Marshal(errorObj)
+		errStr, _ := sonic.Marshal(errorObj)
 		assert.Contains(t, string(errStr), "ErrJsonRpcRequestUnmarshal")
 	})
 
@@ -338,7 +338,7 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 		assert.Equal(t, http.StatusUnsupportedMediaType, statusCode)
 
 		var errorResponse map[string]interface{}
-		err := json.Unmarshal([]byte(body), &errorResponse)
+		err := sonic.Unmarshal([]byte(body), &errorResponse)
 		require.NoError(t, err)
 
 		assert.Contains(t, errorResponse, "error")
@@ -368,7 +368,7 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 		require.NoError(t, err)
 
 		var errorResponse map[string]interface{}
-		err = json.Unmarshal(body, &errorResponse)
+		err = sonic.Unmarshal(body, &errorResponse)
 		require.NoError(t, err)
 
 		assert.Contains(t, errorResponse, "error")
@@ -392,12 +392,12 @@ func TestHttpServer_SingleUpstream(t *testing.T) {
 		assert.Equal(t, http.StatusGatewayTimeout, statusCode)
 
 		var errorResponse map[string]interface{}
-		err := json.Unmarshal([]byte(body), &errorResponse)
+		err := sonic.Unmarshal([]byte(body), &errorResponse)
 		require.NoError(t, err)
 
 		assert.Contains(t, errorResponse, "error")
 		errorObj := errorResponse["error"].(map[string]interface{})
-		errStr, _ := json.Marshal(errorObj)
+		errStr, _ := sonic.Marshal(errorObj)
 		assert.Contains(t, string(errStr), "ErrEndpointRequestTimeout")
 
 		assert.True(t, gock.IsDone(), "All mocks should have been called")

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 require (
 	github.com/IGLOU-EU/go-wildcard/v2 v2.0.2
 	github.com/aws/aws-sdk-go v1.55.4
-	github.com/bytedance/sonic v1.12.1
+	github.com/bytedance/sonic v1.12.2
 	github.com/ethereum/go-ethereum v1.14.7
 	github.com/failsafe-go/failsafe-go v0.6.8
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
-github.com/bytedance/sonic v1.12.1 h1:jWl5Qz1fy7X1ioY74WqO0KjAMtAGQs4sYnjiEBiyX24=
-github.com/bytedance/sonic v1.12.1/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
+github.com/bytedance/sonic v1.12.2 h1:oaMFuRTpMHYLpCntGca65YWt5ny+wAceDERTkT2L9lg=
+github.com/bytedance/sonic v1.12.2/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.0 h1:zNprn+lsIP06C/IqCHs3gPQIvnvpKbbxyXQP1iU4kWM=
 github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 15s
-  evaluation_interval: 15s
+  scrape_interval: 10s
+  evaluation_interval: 10s
 
 rule_files:
   - alert.rules

--- a/test/cmd/main.go
+++ b/test/cmd/main.go
@@ -15,9 +15,9 @@ import (
 func main() {
 	// Define server configurations
 	serverConfigs := []test.ServerConfig{
-		{Port: 8081, FailureRate: 0.1, MinDelay: 50 * time.Millisecond, MaxDelay: 200 * time.Millisecond, SampleFile: "test/samples/evm-json-rpc.json"},
-		{Port: 8082, FailureRate: 0.2, MinDelay: 100 * time.Millisecond, MaxDelay: 300 * time.Millisecond, SampleFile: "test/samples/evm-json-rpc.json"},
-		{Port: 8083, FailureRate: 0.05, MinDelay: 30 * time.Millisecond, MaxDelay: 150 * time.Millisecond, SampleFile: "test/samples/evm-json-rpc.json"},
+		{Port: 8081, FailureRate: 0.1, LimitedRate: 0.9, MinDelay: 50 * time.Millisecond, MaxDelay: 200 * time.Millisecond, SampleFile: "test/samples/evm-json-rpc.json"},
+		{Port: 8082, FailureRate: 0.3, LimitedRate: 0.8, MinDelay: 100 * time.Millisecond, MaxDelay: 300 * time.Millisecond, SampleFile: "test/samples/evm-json-rpc.json"},
+		{Port: 8083, FailureRate: 0.05, LimitedRate: 0.9, MinDelay: 30 * time.Millisecond, MaxDelay: 150 * time.Millisecond, SampleFile: "test/samples/evm-json-rpc.json"},
 	}
 
 	// Create fake servers using the existing function

--- a/test/fake_erpc.go
+++ b/test/fake_erpc.go
@@ -24,6 +24,7 @@ import (
 type ServerConfig struct {
 	Port             int
 	FailureRate      float64
+	LimitedRate      float64
 	MinDelay         time.Duration
 	MaxDelay         time.Duration
 	SampleFile       string
@@ -105,6 +106,7 @@ func CreateFakeServers(configs []ServerConfig) []*FakeServer {
 		server, err := NewFakeServer(
 			config.Port,
 			config.FailureRate,
+			config.LimitedRate,
 			config.MinDelay,
 			config.MaxDelay,
 			config.SampleFile,

--- a/upstream/http_json_json_client_test.go
+++ b/upstream/http_json_json_client_test.go
@@ -2,13 +2,13 @@ package upstream
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/erpc/erpc/common"
 	"github.com/h2non/gock"
 	"github.com/rs/zerolog"
@@ -415,7 +415,7 @@ func TestHttpJsonRpcClient_BatchRequests(t *testing.T) {
 				req := common.NewNormalizedRequest([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"eth_blockNumber","params":[]}`, id)))
 				_, err := client.SendRequest(context.Background(), req)
 				assert.Error(t, err)
-				txt, _ := json.Marshal(err)
+				txt, _ := sonic.Marshal(err)
 				assert.Contains(t, string(txt), "ErrEndpointCapacityExceeded")
 			}(i + 1)
 		}

--- a/upstream/http_json_rpc_client.go
+++ b/upstream/http_json_rpc_client.go
@@ -220,7 +220,7 @@ func (c *GenericHttpJsonRpcClient) processBatch() {
 			)
 			continue
 		}
-		req.request.Mu.RLock()
+		req.request.RLock()
 		batchReq = append(batchReq, common.JsonRpcRequest{
 			JSONRPC: jrReq.JSONRPC,
 			Method:  jrReq.Method,
@@ -231,7 +231,7 @@ func (c *GenericHttpJsonRpcClient) processBatch() {
 
 	requestBody, err := sonic.Marshal(batchReq)
 	for _, req := range requests {
-		req.request.Mu.RUnlock()
+		req.request.RUnlock()
 	}
 	if err != nil {
 		for _, req := range requests {
@@ -390,14 +390,14 @@ func (c *GenericHttpJsonRpcClient) sendSingleRequest(ctx context.Context, req *c
 		)
 	}
 
-	req.Mu.RLock()
+	req.RLock()
 	requestBody, err := sonic.Marshal(common.JsonRpcRequest{
 		JSONRPC: jrReq.JSONRPC,
 		Method:  jrReq.Method,
 		Params:  jrReq.Params,
 		ID:      jrReq.ID,
 	})
-	req.Mu.RUnlock()
+	req.RUnlock()
 
 	if err != nil {
 		return nil, err

--- a/upstream/http_json_rpc_client.go
+++ b/upstream/http_json_rpc_client.go
@@ -683,7 +683,8 @@ func extractJsonRpcError(r *http.Response, nr *common.NormalizedResponse, jr *co
 				),
 			)
 		} else if strings.Contains(err.Message, "Invalid Request") ||
-			strings.Contains(err.Message, "validation errors") {
+			strings.Contains(err.Message, "validation errors") ||
+			strings.Contains(err.Message, "invalid argument") {
 			return common.NewErrEndpointClientSideException(
 				common.NewErrJsonRpcExceptionInternal(
 					int(code),


### PR DESCRIPTION
## What?
This PR rebases main onto polymer-develop so that the changes in v0.0.24 are included.
## Why?
According to the developer of eRPC, these changes should help with high traffic scenarios.
## How?
Just performed a rebase of main onto polymer-develop
## Testing?
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced release process with manual triggering and version tagging in GitHub Actions.
	- Introduced Gosec security scanner in the CI workflow to improve security checks.
	- Added time-to-live (TTL) management capabilities across various connectors (Redis, Memory, PostgreSQL, DynamoDB, Mock).
	- New error types for improved error handling and reporting.

- **Bug Fixes**
	- Corrected minor issues in the configuration structures for better type safety.

- **Chores**
	- Updated Dockerfile for improved binary management and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->