### PR TITLE
add connPoolSize limit

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -63,17 +63,19 @@ type TLSConfig struct {
 }
 
 type RedisConnectorConfig struct {
-	Addr     string     `yaml:"addr" json:"addr"`
-	Password string     `yaml:"password" json:"password"`
-	DB       int        `yaml:"db" json:"db"`
-	TLS      *TLSConfig `yaml:"tls" json:"tls"`
+	Addr         string     `yaml:"addr" json:"addr"`
+	Password     string     `yaml:"password" json:"password"`
+	DB           int        `yaml:"db" json:"db"`
+	TLS          *TLSConfig `yaml:"tls" json:"tls"`
+	ConnPoolSize int        `yaml:"connPoolSize" json:"connPoolSize"`
 }
 
 func (r *RedisConnectorConfig) MarshalJSON() ([]byte, error) {
 	return sonic.Marshal(map[string]interface{}{
-		"addr":     r.Addr,
-		"password": "REDACTED",
-		"db":       r.DB,
+		"addr":         r.Addr,
+		"password":     "REDACTED",
+		"db":           r.DB,
+		"connPoolSize": r.ConnPoolSize,
 	})
 }
 

--- a/data/redis.go
+++ b/data/redis.go
@@ -67,6 +67,7 @@ func (r *RedisConnector) connect(ctx context.Context, cfg *common.RedisConnector
 		Addr:     cfg.Addr,
 		Password: cfg.Password,
 		DB:       cfg.DB,
+		PoolSize: cfg.ConnPoolSize,
 	}
 
 	if cfg.TLS != nil && cfg.TLS.Enabled {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for Redis connections, allowing users to specify the connection pool size.
- **Bug Fixes**
	- Corrected the YAML tag for the TTL field in the MethodCacheConfig struct for improved serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->