### PR TITLE
Feat : Add non cacheable methods

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -48,7 +48,7 @@ type ConnectorConfig struct {
 	DynamoDB            *DynamoDBConnectorConfig     `yaml:"dynamodb" json:"dynamodb"`
 	PostgreSQL          *PostgreSQLConnectorConfig   `yaml:"postgresql" json:"postgresql"`
 	Methods             []*MethodCacheConfig         `yaml:"methods" json:"methods"`
-	NonCacheableMethods []*NonCacheableMethodsConfig `yaml:"noncachable-methods" json:"noncacheable-methods"`
+	NonCacheableMethods []*NonCacheableMethodsConfig `yaml:"noncacheable-methods" json:"noncacheable-methods"`
 }
 
 type MemoryConnectorConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -42,13 +42,13 @@ type DatabaseConfig struct {
 }
 
 type ConnectorConfig struct {
-	Driver             string                       `yaml:"driver" json:"driver"`
-	Memory             *MemoryConnectorConfig       `yaml:"memory" json:"memory"`
-	Redis              *RedisConnectorConfig        `yaml:"redis" json:"redis"`
-	DynamoDB           *DynamoDBConnectorConfig     `yaml:"dynamodb" json:"dynamodb"`
-	PostgreSQL         *PostgreSQLConnectorConfig   `yaml:"postgresql" json:"postgresql"`
-	Methods            []*MethodCacheConfig         `yaml:"methods" json:"methods"`
-	NonCachableMethods []*NonCacheableMethodsConfig `yaml:"noncachable-methods" json:"noncacheable-methods"`
+	Driver              string                       `yaml:"driver" json:"driver"`
+	Memory              *MemoryConnectorConfig       `yaml:"memory" json:"memory"`
+	Redis               *RedisConnectorConfig        `yaml:"redis" json:"redis"`
+	DynamoDB            *DynamoDBConnectorConfig     `yaml:"dynamodb" json:"dynamodb"`
+	PostgreSQL          *PostgreSQLConnectorConfig   `yaml:"postgresql" json:"postgresql"`
+	Methods             []*MethodCacheConfig         `yaml:"methods" json:"methods"`
+	NonCacheableMethods []*NonCacheableMethodsConfig `yaml:"noncachable-methods" json:"noncacheable-methods"`
 }
 
 type MemoryConnectorConfig struct {

--- a/common/config.go
+++ b/common/config.go
@@ -42,12 +42,13 @@ type DatabaseConfig struct {
 }
 
 type ConnectorConfig struct {
-	Driver     string                     `yaml:"driver" json:"driver"`
-	Memory     *MemoryConnectorConfig     `yaml:"memory" json:"memory"`
-	Redis      *RedisConnectorConfig      `yaml:"redis" json:"redis"`
-	DynamoDB   *DynamoDBConnectorConfig   `yaml:"dynamodb" json:"dynamodb"`
-	PostgreSQL *PostgreSQLConnectorConfig `yaml:"postgresql" json:"postgresql"`
-	Methods    []*MethodCacheConfig       `yaml:"methods" json:"methods"`
+	Driver             string                       `yaml:"driver" json:"driver"`
+	Memory             *MemoryConnectorConfig       `yaml:"memory" json:"memory"`
+	Redis              *RedisConnectorConfig        `yaml:"redis" json:"redis"`
+	DynamoDB           *DynamoDBConnectorConfig     `yaml:"dynamodb" json:"dynamodb"`
+	PostgreSQL         *PostgreSQLConnectorConfig   `yaml:"postgresql" json:"postgresql"`
+	Methods            []*MethodCacheConfig         `yaml:"methods" json:"methods"`
+	NonCachableMethods []*NonCacheableMethodsConfig `yaml:"noncachable-methods" json:"noncacheable-methods"`
 }
 
 type MemoryConnectorConfig struct {
@@ -82,6 +83,9 @@ func (r *RedisConnectorConfig) MarshalJSON() ([]byte, error) {
 type MethodCacheConfig struct {
 	Method string `yaml:"method" json:"method"`
 	TTL    string `yamle:"ttl" json:"ttl"`
+}
+type NonCacheableMethodsConfig struct {
+	Method string `yaml:"method" json:"method"`
 }
 
 type DynamoDBConnectorConfig struct {

--- a/data/connector.go
+++ b/data/connector.go
@@ -17,6 +17,8 @@ type Connector interface {
 	Set(ctx context.Context, partitionKey, rangeKey, value string) error
 	SetTTL(method string, ttlStr string) error
 	HasTTL(method string) bool
+	IgnoreMethod(method string) error
+	IsMethodIgnored(method string) bool
 	Delete(ctx context.Context, index, partitionKey, rangeKey string) error
 }
 

--- a/data/dynamodb.go
+++ b/data/dynamodb.go
@@ -270,6 +270,15 @@ func (d *DynamoDBConnector) HasTTL(_ string) bool {
 	return false
 }
 
+func (d *DynamoDBConnector) IgnoreMethod(_ string) error {
+	d.logger.Debug().Msgf("Ignore Method not implemented for DynamoDBConnector")
+	return nil
+}
+
+func (d *DynamoDBConnector) IsMethodIgnored(_ string) bool {
+	return false
+}
+
 func (d *DynamoDBConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	if d.client == nil {
 		return fmt.Errorf("DynamoDB client not initialized yet")

--- a/data/memory.go
+++ b/data/memory.go
@@ -51,6 +51,15 @@ func (d *MemoryConnector) HasTTL(_ string) bool {
 	return false
 }
 
+func (d *MemoryConnector) IgnoreMethod(_ string) error {
+	d.logger.Debug().Msgf("Ignore Method not implemented for MemoryConnector")
+	return nil
+}
+
+func (d *MemoryConnector) IsMethodIgnored(_ string) bool {
+	return false
+}
+
 func (m *MemoryConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	m.cache.Add(key, value)

--- a/data/memory.go
+++ b/data/memory.go
@@ -47,16 +47,16 @@ func (m *MemoryConnector) SetTTL(_ string, _ string) error {
 	return nil
 }
 
-func (d *MemoryConnector) HasTTL(_ string) bool {
+func (m *MemoryConnector) HasTTL(_ string) bool {
 	return false
 }
 
-func (d *MemoryConnector) IgnoreMethod(_ string) error {
-	d.logger.Debug().Msgf("Ignore Method not implemented for MemoryConnector")
+func (m *MemoryConnector) IgnoreMethod(_ string) error {
+	m.logger.Debug().Msgf("Ignore Method not implemented for MemoryConnector")
 	return nil
 }
 
-func (d *MemoryConnector) IsMethodIgnored(_ string) bool {
+func (m *MemoryConnector) IsMethodIgnored(_ string) bool {
 	return false
 }
 

--- a/data/mock_connector.go
+++ b/data/mock_connector.go
@@ -41,6 +41,18 @@ func (m *MockConnector) HasTTL(method string) bool {
 	return args.Bool(0)
 }
 
+// IgnoreMethod mocks the IgnoreMethod method of the Connector interface
+func (m *MockConnector) IgnoreMethod(method string) error {
+	args := m.Called(method)
+	return args.Error(0)
+}
+
+// IsMethodIgnored mocks the IsMethodIgnored method of the Connector interface
+func (m *MockConnector) IsMethodIgnored(method string) bool {
+	args := m.Called(method)
+	return args.Bool(0)
+}
+
 // NewMockConnector creates a new instance of MockConnector
 func NewMockConnector() *MockConnector {
 	return &MockConnector{}

--- a/data/postgresql.go
+++ b/data/postgresql.go
@@ -98,6 +98,15 @@ func (p *PostgreSQLConnector) HasTTL(_ string) bool {
 	return false
 }
 
+func (d *PostgreSQLConnector) IgnoreMethod(_ string) error {
+	d.logger.Debug().Msgf("Ignore Method not implemented for PostgreSQLConnector")
+	return nil
+}
+
+func (d *PostgreSQLConnector) IsMethodIgnored(_ string) bool {
+	return false
+}
+
 func (p *PostgreSQLConnector) Set(ctx context.Context, partitionKey, rangeKey, value string) error {
 	if p.conn == nil {
 		return fmt.Errorf("PostgreSQLConnector not connected yet")

--- a/data/redis.go
+++ b/data/redis.go
@@ -148,6 +148,12 @@ func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value 
 
 	r.logger.Debug().Msgf("writing to Redis with partition key: %s and range key: %s", partitionKey, rangeKey)
 	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
+
+	if _, found := r.ignoreMethod[method]; found {
+
+		return nil
+	}
+
 	ttl, found := r.ttls[method]
 	if !found {
 		ttl = time.Duration(0)
@@ -160,6 +166,12 @@ func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value 
 func (r *RedisConnector) Get(ctx context.Context, index, partitionKey, rangeKey string) (string, error) {
 	if r.client == nil {
 		return "", fmt.Errorf("redis client not initialized yet")
+	}
+
+	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
+	if _, found := r.ignoreMethod[method]; found {
+
+		return "", common.NewErrRecordNotFound("Method is uncacheable", RedisDriverName)
 	}
 
 	var err error

--- a/data/redis.go
+++ b/data/redis.go
@@ -149,7 +149,7 @@ func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value 
 	r.logger.Debug().Msgf("writing to Redis with partition key: %s and range key: %s", partitionKey, rangeKey)
 	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
 
-	if isIgnored := r.IsMethodIgnored(method); isIgnored {
+	if r.IsMethodIgnored(method) {
 
 		return nil
 	}
@@ -169,9 +169,9 @@ func (r *RedisConnector) Get(ctx context.Context, index, partitionKey, rangeKey 
 	}
 
 	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
-	if isIgnored := r.IsMethodIgnored(method); isIgnored {
+	if r.IsMethodIgnored(method) {
 
-		return "", common.NewErrRecordNotFound("Method is uncacheable", RedisDriverName)
+		return "", common.NewErrRecordNotFound(fmt.Sprintf("Method %s is configured to bypass cache", method), RedisDriverName)
 	}
 
 	var err error

--- a/data/redis.go
+++ b/data/redis.go
@@ -22,9 +22,10 @@ const (
 var _ Connector = (*RedisConnector)(nil)
 
 type RedisConnector struct {
-	logger *zerolog.Logger
-	client *redis.Client
-	ttls   map[string]time.Duration
+	logger       *zerolog.Logger
+	client       *redis.Client
+	ttls         map[string]time.Duration
+	ignoreMethod map[string]bool
 }
 
 func NewRedisConnector(
@@ -35,8 +36,9 @@ func NewRedisConnector(
 	logger.Debug().Msgf("creating RedisConnector with config: %+v", cfg)
 
 	connector := &RedisConnector{
-		logger: logger,
-		ttls:   make(map[string]time.Duration),
+		logger:       logger,
+		ttls:         make(map[string]time.Duration),
+		ignoreMethod: make(map[string]bool),
 	}
 
 	// Attempt the actual connecting in background to avoid blocking the main thread.
@@ -126,6 +128,16 @@ func (r *RedisConnector) SetTTL(method string, ttlStr string) error {
 
 func (r *RedisConnector) HasTTL(method string) bool {
 	_, found := r.ttls[strings.ToLower(method)]
+	return found
+}
+
+func (r *RedisConnector) IgnoreMethod(method string) error {
+	r.ignoreMethod[strings.ToLower(method)] = true
+	return nil
+}
+
+func (r *RedisConnector) IsMethodIgnored(method string) bool {
+	_, found := r.ignoreMethod[strings.ToLower(method)]
 	return found
 }
 

--- a/data/redis.go
+++ b/data/redis.go
@@ -149,7 +149,7 @@ func (r *RedisConnector) Set(ctx context.Context, partitionKey, rangeKey, value 
 	r.logger.Debug().Msgf("writing to Redis with partition key: %s and range key: %s", partitionKey, rangeKey)
 	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
 
-	if _, found := r.ignoreMethod[method]; found {
+	if isIgnored := r.IsMethodIgnored(method); isIgnored {
 
 		return nil
 	}
@@ -169,7 +169,7 @@ func (r *RedisConnector) Get(ctx context.Context, index, partitionKey, rangeKey 
 	}
 
 	method := strings.ToLower(strings.Split(rangeKey, ":")[0])
-	if _, found := r.ignoreMethod[method]; found {
+	if isIgnored := r.IsMethodIgnored(method); isIgnored {
 
 		return "", common.NewErrRecordNotFound("Method is uncacheable", RedisDriverName)
 	}

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -44,9 +44,12 @@ func NewEvmJsonRpcCache(ctx context.Context, logger *zerolog.Logger, cfg *common
 
 	// set non cacheable methods
 	for _, cacheInfo := range cfg.NonCachableMethods {
+		logger.Debug().Str("method", cacheInfo.Method).Msg("configuring non-cacheable method")
 		if err := c.IgnoreMethod(cacheInfo.Method); err != nil {
 			return nil, err
 		}
+		logger.Debug().Str("method", cacheInfo.Method).Msg("successfully configured non-cacheable method")
+
 	}
 
 	return &EvmJsonRpcCache{
@@ -68,6 +71,11 @@ func (c *EvmJsonRpcCache) Get(ctx context.Context, req *common.NormalizedRequest
 	rpcReq, err := req.JsonRpcRequest()
 	if err != nil {
 		return nil, err
+	}
+
+	// Skip cache for ignored methods
+	if c.conn.IsMethodIgnored(rpcReq.Method) {
+		return nil, nil
 	}
 
 	hasTTL := c.conn.HasTTL(rpcReq.Method)
@@ -127,6 +135,11 @@ func (c *EvmJsonRpcCache) Set(ctx context.Context, req *common.NormalizedRequest
 	rpcResp, err := resp.JsonRpcResponse()
 	if err != nil {
 		return err
+	}
+
+	// Skip cache for ignored methods
+	if c.conn.IsMethodIgnored(rpcReq.Method) {
+		return nil
 	}
 
 	lg := c.logger.With().Str("networkId", req.NetworkId()).Str("method", rpcReq.Method).Logger()

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -43,7 +43,7 @@ func NewEvmJsonRpcCache(ctx context.Context, logger *zerolog.Logger, cfg *common
 	}
 
 	// set non cacheable methods
-	for _, cacheInfo := range cfg.NonCachableMethods {
+	for _, cacheInfo := range cfg.NonCacheableMethods {
 		logger.Debug().Str("method", cacheInfo.Method).Msg("configuring non-cacheable method")
 		if err := c.IgnoreMethod(cacheInfo.Method); err != nil {
 			return nil, err

--- a/erpc/evm_json_rpc_cache.go
+++ b/erpc/evm_json_rpc_cache.go
@@ -42,6 +42,13 @@ func NewEvmJsonRpcCache(ctx context.Context, logger *zerolog.Logger, cfg *common
 		}
 	}
 
+	// set non cacheable methods
+	for _, cacheInfo := range cfg.NonCachableMethods {
+		if err := c.IgnoreMethod(cacheInfo.Method); err != nil {
+			return nil, err
+		}
+	}
+
 	return &EvmJsonRpcCache{
 		conn:   c,
 		logger: logger,

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -81,6 +81,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -97,6 +98,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -150,6 +152,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 				mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 				mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+				mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 				err := cache.Set(context.Background(), req, resp)
 
@@ -170,6 +173,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -184,6 +188,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":{"number":"0x399","hash":"0xdef"}}`))
 
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -198,6 +203,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
 
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -212,6 +218,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
 
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -226,6 +233,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
 
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -240,6 +248,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"result":"0x0"}`))
 
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 		err := cache.Set(context.Background(), req, resp)
 
 		assert.NoError(t, err)
@@ -255,6 +264,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 		mockConnector.On("Set", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -273,6 +283,7 @@ func TestEvmJsonRpcCache_Get(t *testing.T) {
 		cachedResponse := `{"number":"0x1","hash":"0xabc"}`
 		mockConnector.On("Get", mock.Anything, mock.Anything, "evm:123:1", mock.Anything).Return(cachedResponse, nil)
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		resp, err := cache.Get(context.Background(), req)
 
@@ -290,6 +301,7 @@ func TestEvmJsonRpcCache_Get(t *testing.T) {
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x32345",false],"id":1}`))
 		req.SetNetwork(mockNetwork)
 		mockConnector.On("HasTTL", mock.AnythingOfType("string")).Return(false)
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 		resp, err := cache.Get(context.Background(), req)
 
 		assert.NoError(t, err)

--- a/erpc/evm_json_rpc_cache_test.go
+++ b/erpc/evm_json_rpc_cache_test.go
@@ -65,6 +65,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x123"],"id":1}`))
 		resp := common.NewNormalizedResponse().WithBody([]byte(`{"hash":"0x123","blockNumber":null}`))
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 
@@ -111,6 +112,7 @@ func TestEvmJsonRpcCache_Set(t *testing.T) {
 
 		req := common.NewNormalizedRequest([]byte(`{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1}`))
 		resp := common.NewNormalizedResponse().WithBody([]byte(`"0x1234"`))
+		mockConnector.On("IsMethodIgnored", mock.AnythingOfType("string")).Return(false)
 
 		err := cache.Set(context.Background(), req, resp)
 

--- a/erpc/networks.go
+++ b/erpc/networks.go
@@ -136,6 +136,7 @@ func (n *Network) Forward(ctx context.Context, req *common.NormalizedRequest) (*
 		resp, err := n.cacheDal.Get(cctx, req)
 		if err != nil {
 			lg.Debug().Err(err).Msgf("could not find response in cache")
+			// Consider deferring this metric increment
 			health.MetricNetworkCacheMisses.WithLabelValues(n.ProjectId, n.NetworkId, method).Inc()
 		} else if resp != nil && !resp.IsObjectNull() && !resp.IsResultEmptyish() {
 			lg.Info().Msgf("response served from cache")


### PR DESCRIPTION
## What?
This adds the ability to skip caching specific methods
## Why?
Batched requests for `eth_TransactionReceipt` take too long, but when we remove cache checking, then the response time is similar for other caching systems.
## How?
Added IgnoreMetho() and IsMethodIgnored() methods to have cache reads/writes return early if the method is supposed to be ignored.
## Testing?
Tested this with op-node and it works fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added methods for managing ignored methods across various connector implementations (e.g., `IgnoreMethod` and `IsMethodIgnored`).
	- Enhanced `RedisConnector` with a new field for tracking ignored methods.
	- Introduced a configuration option for specifying non-cacheable methods.
	- Improved caching logic to skip caching for methods marked as non-cacheable.

- **Bug Fixes**
	- Improved error handling and metric management in the `Forward` method of the `Network` struct.
	- Enhanced robustness of the `normalizeResponse` method to ensure correct ID usage.

These updates enhance functionality and robustness, providing better control over method management and error handling across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->